### PR TITLE
Removing the root babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,1 +1,0 @@
-// TODO: Configure me


### PR DESCRIPTION
<!-- Please fill out this template when opening a new PR. Thanks! -->
We may want a standard babel config across multiple packages using lerna, but this isn't the right way to achieve that, so we can remove this file.

### Issue link
<!--- Is there an open issue for this PR? If so, please link to it.--->
n/a


### Types of changes
Other (please describe below if you select "Other")
Removing an unneeded config file
