### PR TITLE
Action: Throw error event when tx.status = 0

### DIFF
--- a/packages/tasit-action/src/contract/Action.js
+++ b/packages/tasit-action/src/contract/Action.js
@@ -77,7 +77,10 @@ export class Action extends Subscription {
     const baseEthersListener = async blockNumber => {
       try {
         if (!this.#tx) this.#tx = await this.#txPromise;
-
+        
+        if (this.#tx.status == 0) {
+          throw new Error(`Transaction has failed and it's status is 0`);
+        }
         const receipt = await this.#provider.getTransactionReceipt(
           this.#tx.hash
         );


### PR DESCRIPTION
<!-- Please fill out this template when opening a new PR. Thanks! -->

### Issue link
https://github.com/tasitlabs/TasitSDK/issues/206

<!--- Is there an open issue for this PR? If so, please link to it.--->

### Auto-close the issue?

<!---
If this PR should close the associated issue when it's merged, please change XXX below to the issue number.
Otherwise, you can remove this section.
--->

Closes #206  

### Types of changes

<!--- What type(s) of change(s) does your code introduce? Please delete any that don't apply: -->

New feature (non-breaking change that adds functionality)

In the Action.js file, the baseEthersListener doesn't emit an error when the transaction has failed (ie. status is 0). 

### Notes

<!--- Any other context to be aware of when reviewing this PR -->
I was not sure on what error message to emit, so I just wrote a standard one. Please feel free to change it to your liking.
